### PR TITLE
Delete DescribeSecurityGroupRules SecurityGroup Required

### DIFF
--- a/2013-08-30/swagger/security_group.json
+++ b/2013-08-30/swagger/security_group.json
@@ -352,10 +352,7 @@
                 "type": "integer",
                 "default": 20
               }
-            },
-            "required": [
-              "security_group"
-            ]
+            }
           }
         }
       ],


### PR DESCRIPTION
According to https://docs.qingcloud.com/api/sg/describe_security_group_rules.html.
If no filtering conditions are specified , by default, return all the rules for all the SecurityGroup you have .
So , SecurityGroup should not be required .