### PR TITLE
kyon/owner Add `owner` in several api request

### DIFF
--- a/2013-08-30/swagger/eip.json
+++ b/2013-08-30/swagger/eip.json
@@ -53,6 +53,9 @@
                   "type": "string"
                 }
               },
+              "owner": {
+                "type": "string"
+              },
               "verbose": {
                 "type": "integer"
               },

--- a/2013-08-30/swagger/image.json
+++ b/2013-08-30/swagger/image.json
@@ -75,6 +75,9 @@
                   0
                 ]
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0

--- a/2013-08-30/swagger/instance.json
+++ b/2013-08-30/swagger/instance.json
@@ -84,6 +84,9 @@
                 "type": "integer",
                 "default": 20
               },
+              "owner": {
+                "type": "string"
+              },
               "is_cluster_node": {
                 "type": "integer",
                 "default": 0

--- a/2013-08-30/swagger/job.json
+++ b/2013-08-30/swagger/job.json
@@ -47,6 +47,9 @@
                   0
                 ]
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0

--- a/2013-08-30/swagger/key_pair.json
+++ b/2013-08-30/swagger/key_pair.json
@@ -50,6 +50,9 @@
                 "type": "integer",
                 "default": 0
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0

--- a/2013-08-30/swagger/load_balancer.json
+++ b/2013-08-30/swagger/load_balancer.json
@@ -140,6 +140,9 @@
                 "type": "integer",
                 "default": 0
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0
@@ -751,6 +754,9 @@
               "verbose": {
                 "type": "integer"
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0
@@ -1029,6 +1035,9 @@
               "verbose": {
                 "type": "integer"
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0
@@ -1281,6 +1290,9 @@
               },
               "verbose": {
                 "type": "integer"
+              },
+              "owner": {
+                "type": "string"
               },
               "offset": {
                 "type": "integer",
@@ -1582,6 +1594,9 @@
               "loadbalancer_policy": {
                 "type": "string"
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0
@@ -1833,6 +1848,9 @@
               "verbose": {
                 "type": "integer",
                 "default": 0
+              },
+              "owner": {
+                "type": "string"
               },
               "offset": {
                 "type": "integer",

--- a/2013-08-30/swagger/nic.json
+++ b/2013-08-30/swagger/nic.json
@@ -56,6 +56,9 @@
               "nic_name": {
                 "type": "string"
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0

--- a/2013-08-30/swagger/router.json
+++ b/2013-08-30/swagger/router.json
@@ -60,6 +60,9 @@
                   1
                 ]
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer"
               },
@@ -687,6 +690,9 @@
                   1
                 ]
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0
@@ -1313,6 +1319,9 @@
                 "type": "string"
               },
               "router_static": {
+                "type": "string"
+              },
+              "owner": {
                 "type": "string"
               },
               "offset": {

--- a/2013-08-30/swagger/security_group.json
+++ b/2013-08-30/swagger/security_group.json
@@ -40,6 +40,9 @@
                 "type": "integer",
                 "default": 0
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0
@@ -343,6 +346,9 @@
                   0,
                   1
                 ]
+              },
+              "owner": {
+                "type": "string"
               },
               "offset": {
                 "type": "integer",
@@ -895,6 +901,9 @@
               "verbose": {
                 "type": "integer",
                 "default": 0
+              },
+              "owner": {
+                "type": "string"
               },
               "offset": {
                 "type": "integer",

--- a/2013-08-30/swagger/snapshot.json
+++ b/2013-08-30/swagger/snapshot.json
@@ -70,6 +70,9 @@
                   1
                 ]
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0

--- a/2013-08-30/swagger/volume.json
+++ b/2013-08-30/swagger/volume.json
@@ -67,6 +67,9 @@
                   1
                 ]
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0

--- a/2013-08-30/swagger/vxnet.json
+++ b/2013-08-30/swagger/vxnet.json
@@ -51,6 +51,9 @@
                   1
                 ]
               },
+              "owner": {
+                "type": "string"
+              },
               "offset": {
                 "type": "integer",
                 "default": 0


### PR DESCRIPTION
- DescribeInstances
- DescribeEips
- DescribeImages
- DescribeJobs
- DescribeKeyPairs
- DescribeNics
- DescribeLoadBalancers
- DescribeLoadBalancerListeners
- DescribeLoadBalancerPolicies
- DescribeLoadBalancerPolicyRules
- DescribeLoadBalancerBackends
- DescribeServerCertificates
- DescribeRouters
- DescribeRouterStatics
- DescribeRoutersStaticEntries
- DescribeSecurityGroups
- DescribeSecurityGroupRules
- DescribeSecurityGroupIPSets
- DescribeSnapshots
- DescribeVolumes
- DescribeVxnets